### PR TITLE
Fix playback range timer when switching songs

### DIFF
--- a/main.js
+++ b/main.js
@@ -180,6 +180,7 @@ window.renderCurrentPlaylist = renderCurrentPlaylist;
 // 曲を再生
 function playSongSection(idx) {
   hideTimeEditPopup();
+  cancelEndTimer();
   const song = playlistData[idx];
   if (!song) return;
   currentPlayingIdx = idx;


### PR DESCRIPTION
## Summary
- stop any active end-of-section timer when starting playback of a new list item
- prevent the previous timer from skipping ahead or overrunning the configured range

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9c2e5b06c832db1c8d1e134c9c4c4